### PR TITLE
Add GitHub OAuth callback handler

### DIFF
--- a/cmd/oauth-proxy/main.go
+++ b/cmd/oauth-proxy/main.go
@@ -31,6 +31,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", h.HealthCheck)
 	mux.HandleFunc("GET /api/auth/google/callback", h.HandleCallback)
+	mux.HandleFunc("GET /api/auth/github/callback", h.HandleCallback)
 
 	server := &http.Server{
 		Addr:         ":" + cfg.Port,


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add GitHub OAuth callback handler

## Additional Information

It's used to import ssh keys from GitHub in clustron-backend repository.
