### PR TITLE
Change callback endpoint param form static string to wildcard

### DIFF
--- a/cmd/oauth-proxy/main.go
+++ b/cmd/oauth-proxy/main.go
@@ -30,8 +30,7 @@ func main() {
 	// Setup HTTP server
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", h.HealthCheck)
-	mux.HandleFunc("GET /api/auth/google/callback", h.HandleCallback)
-	mux.HandleFunc("GET /api/auth/github/callback", h.HandleCallback)
+	mux.HandleFunc("GET /api/auth/{provider}/callback", h.HandleCallback)
 
 	server := &http.Server{
 		Addr:         ":" + cfg.Port,


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Refactor OAuth callback route to support generic providers (e.g., GitHub, Google, NYCU portal)

## Additional Information
This change enables dynamic provider routing.
Specifically, it is required to import SSH keys from GitHub and login via NYCU protal for the clustron-backend service.